### PR TITLE
use type of route to redirect instead of redirect controller of symfony

### DIFF
--- a/src/Adapter/OrmAdapter.php
+++ b/src/Adapter/OrmAdapter.php
@@ -174,19 +174,7 @@ class OrmAdapter implements AdapterInterface
      */
     public function createRedirectRoute(AutoRouteInterface $referringAutoRoute, AutoRouteInterface $newRoute)
     {
-        // check if $newRoute already exists
-        $route = $this->repository->findOneByStaticPrefix($newRoute->getStaticPrefix());
-
-        if ($route) {
-            // in case it's a redirection, remove redirection's defaults
-            $defaults = $route->getDefaults();
-            unset($defaults['_controller'], $defaults['route'], $defaults['permanent']);
-            $route->setDefaults($defaults);
-            $this->em->flush($route);
-        }
-
         $referringAutoRoute->setRedirectTarget($newRoute);
-        $referringAutoRoute->setPosition($this->calculateReferringRoutePosition($newRoute->getPosition()));
         $referringAutoRoute->setType(AutoRouteInterface::TYPE_REDIRECT);
 
         // WARNING http://doctrine-orm.readthedocs.org/en/latest/reference/events.html#postflush
@@ -287,18 +275,6 @@ class OrmAdapter implements AdapterInterface
         }
 
         $autoRoute->setContent($object);
-    }
-
-    /**
-     * Calculates the new position for redirect urls. Provides an higher number to allow route sorting.
-     *
-     * @param int $newRoutePosition
-     *
-     * @return int
-     */
-    private function calculateReferringRoutePosition($newRoutePosition)
-    {
-        return $newRoutePosition * 10 + 1;
     }
 
     /**

--- a/src/Doctrine/Orm/AutoRoute.php
+++ b/src/Doctrine/Orm/AutoRoute.php
@@ -63,6 +63,11 @@ class AutoRoute extends Route implements AutoRouteInterface
     private $contentId;
 
     /**
+     * @var string
+     */
+    private $redirectTarget;
+
+    /**
      * @return string
      */
     public function __toString()
@@ -155,10 +160,7 @@ class AutoRoute extends Route implements AutoRouteInterface
      */
     public function setRedirectTarget($autoTarget)
     {
-        $this->setDefault('_controller', 'FrameworkBundle:Redirect:redirect');
-        $this->setDefault('route', $autoTarget->getName());
-        $this->setDefault('permanent', true);
-        $this->setDefault('ignoreAttributes', ['type']);
+        $this->redirectTarget = $autoTarget->getName();
 
         return $this;
     }
@@ -168,7 +170,7 @@ class AutoRoute extends Route implements AutoRouteInterface
      */
     public function getRedirectTarget()
     {
-        return $this->getDefault('route');
+        return $this->redirectTarget;
     }
 
     /**

--- a/src/Resources/config/doctrine-model/AutoRoute.orm.xml
+++ b/src/Resources/config/doctrine-model/AutoRoute.orm.xml
@@ -15,6 +15,8 @@
         <field name="contentClass" type="string" nullable="true"/>
         <field name="contentId" type="json_array" nullable="true"/>
 
+        <field name="redirectTarget" type="string" nullable="true"/>
+
         <indexes>
             <index name="name_idx" columns="name"/>
         </indexes>

--- a/tests/Fixtures/App/config/app_config.yml
+++ b/tests/Fixtures/App/config/app_config.yml
@@ -3,10 +3,10 @@ cmf_routing:
         routers_by_id:
             cmf_routing.dynamic_router: 20
             router.default: 100
-#    dynamic:
+    dynamic:
 #        enabled: true
-#        controllers_by_type:
-#            cmf_routing_auto.redirect: cmf_routing_auto.redirect_controller:redirectAction
+        controllers_by_type:
+            cmf_routing_auto.redirect: cmf_routing_auto.redirect_controller:redirectAction
 #        persistence:
 #            orm:
 #                enabled: true

--- a/tests/Functional/EventListener/AutoRouteListenerTest.php
+++ b/tests/Functional/EventListener/AutoRouteListenerTest.php
@@ -226,16 +226,14 @@ class AutoRouteListenerTest extends OrmBaseTestCase
         $this->assertEquals('/blog/unit-testing-blog', $oldRoute->getStaticPrefix());
         $this->assertEquals(
             [
-                '_controller' => 'FrameworkBundle:Redirect:redirect',
+                '_controller' => 'BlogController',
                 '_locale' => 'en',
-                'route' => $newRoute->getName(),
-                'permanent' => true,
                 'type' => 'cmf_routing_auto.redirect',
                 '_route_auto_tag' => 'en',
-                'ignoreAttributes' => ['type'],
             ],
             $oldRoute->getDefaults()
         );
+        $this->assertEquals($newRoute->getName(), $oldRoute->getRedirectTarget());
 
         if ($withPosts) {
             /** @var Post $post */

--- a/tests/WebTest/RedirectTest.php
+++ b/tests/WebTest/RedirectTest.php
@@ -58,7 +58,7 @@ class RedirectTest extends OrmBaseTestCase
         $client = $this->createClient(['environment' => 'orm']);
         $client->request('GET', '/seo-articles/seo-article');
         $resp = $client->getResponse();
-        $this->assertEquals(301, $resp->getStatusCode());
-        $this->assertContains('Redirecting to <a href="http://localhost/seo-articles/renamed-article">http://localhost/seo-articles/renamed-article</a>', $resp->getContent());
+        $this->assertEquals(302, $resp->getStatusCode());
+        $this->assertContains('Redirecting to <a href="/seo-articles/renamed-article">/seo-articles/renamed-article</a>', $resp->getContent());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| License       | MIT

We were creating the redirecting route using the redirect controller of symfony framework. We have changed to use the type of the route.
